### PR TITLE
Pseudo-instructions for the RISC-V 32-bit Base Integer Instruction Set ("RV32I")

### DIFF
--- a/pyrisccore/__init__.py
+++ b/pyrisccore/__init__.py
@@ -1,2 +1,15 @@
-""" a 64-bit virtual machine written in Python
+""" a virtual machine written in Python
 """
+
+
+class PyrisccoreAssertion(Exception):
+    """ it's not me, it's you.
+    """
+
+
+class PyrisccoreError(Exception):
+    """ it's not you, it's me.
+    """
+
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/pyrisccore/vm/forms/instruction.py
+++ b/pyrisccore/vm/forms/instruction.py
@@ -1,197 +1,163 @@
 """ instruction building blocks
-
-You know how you're used to reading arrays left to right, with the left most
-thing in the array being the 0th position? This is the reverse. The furthest
-right position is now the 0th.
-
-This applies to elements in a list too!
-
-Chunks of the bits representation ("fields") are given in right -> left order
-because of this. In any Python list, index 0 corresponds to the
-object closest to the MSB. This makes concatenation easy.
-
-Integers haven't changed, though. The bit on the right has always been the least
-significant bit and it doesn't change in this code. In other words, 0x0001 is 1.
 """
 
-from dataclasses import dataclass
-from struct import iter_unpack, pack, unpack
-from typing import Dict, List, Optional, Tuple, Type
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple, Union
 
+from pyrisccore import PyrisccoreAssertion
 from pyrisccore.vm.forms.register import RegisterFile
 
 
-class Field:
-    """ a slice of a 64-bit value
+class Word:
+    """ useful attributes resultant from xlen
     """
 
-    value: int
+    def __init__(self, xlen: int):
+        self.xlen: int = xlen
+        self.mask: int = (1 << xlen) - 1
 
-    def __init__(self, lsb: int, msb: int):
-        self.lsb: int = lsb
-        self.msb: int = msb
-        self.size: int = msb - lsb + 1
-        self.mask: int = self._mask(lsb, self.size)
+
+WORD = Word(xlen = 32)  # e.g. 32 for "32-bit"
+
+
+@dataclass(
+    frozen=False,       # <- __post_init__() will fail if this is True.
+    unsafe_hash=True    # <- Once a Field is instantiated, it's effectively frozen.
+)
+class Field:
+    """ defines how a slice of an instruction format maps to a usable value
+    """
+
+    # The range of bits in a word for this field's value.
+    source: slice
+
+    # The name of the field; multiple Field instances can share this value
+    # to indicate that the bits of their values come from multiple slices.
+    name: Optional[str] = None
+    source_mask: int = field(init=False)
+
+    # Declare which of the source bits map to specific bits of the value.
+    # For example, see the "imm" field of the J-Type instruction format.
+    destination: Optional[slice] = None
+    destination_mask: Optional[int] = field(init=False, default=None)
+
+    # Declare that the value of this field is linked to the value of another field
+    # rather than the instruction word. This is given as either the name of a field
+    # in the instruction format or as the index of a field in the instruction format
+    # counting from the least significant bit (0-indexing).
+    parent: Optional[Union[str, int]] = None
+
+    # Number of bits required to represent this field's value.
+    size: int = field(init=False)
+
+    def __post_init__(self):
+
+        # Enforce constraints on the source slice
+        self._validate_slice(self.source)
+        size_src = self.source.stop - self.source.start + 1
+
+        # Use the source slice
+        self.source_mask: int = self._mask(self.source.start, size_src)
+        self.size: int = size_src
+
+        # Enforce constraints on the destination slice
+        if self.destination is not None:
+            self._validate_slice(self.destination)
+            size_dst = self.destination.stop - self.destination.start + 1
+            if size_src != size_dst:
+                raise PyrisccoreAssertion(f"'source' and 'destination' slices must be the same size ({size_src} bits vs {size_dst} bits)")
+
+            # Use the destination slice
+            self.destination_mask: int = self._mask(self.destination.start, size_dst)
 
     @staticmethod
-    def _mask(lsb: int, size: int) -> int:
-        """ return a mask given the starting position and quantity of 1s
+    def _validate_slice(s: slice):
+        if s.start is None:
+            raise PyrisccoreAssertion(f"'start' must be provided in the slice: {s}")
+        if s.step is not None and s.step != 1:
+            raise PyrisccoreAssertion(f"'step' must be 1 in the slice: {s}")
+        if s.stop >= WORD.xlen or s.start >= WORD.xlen:
+            raise PyrisccoreAssertion(f"'start' and 'stop' cannot exceed the architecture's XLEN in the slice: {s}")
+        if s.start < 0 or s.stop < 0:
+            raise PyrisccoreAssertion(f"'start' and 'stop' cannot be negative in the slice: {s}")
+
+    @staticmethod
+    def _mask(lsb: int, bit_length: int) -> int:
+        """ return a mask isolating the value of this particular field
         """
-        if size == 0:
+        if bit_length <= 0:
             return 0
-        mask = 0
-        for i in range(size + lsb):
-            mask <<= 1
-            if i < size:
-                mask += 1
-        return mask
+        return ((1 << bit_length) - 1) << lsb
 
-    def set(self, word: int):
-        """ set the value of the field from a 64-bit word
+    @staticmethod
+    def _read(source: int, mask: int, lsb: int) -> int:
+        """ read a value from a source given a mask and the least significant bit
         """
-        self.value = (word & self.mask) >> self.lsb
+        return (source & mask) >> lsb
+
+    @staticmethod
+    def _write(value: int, mask: int, lsb: int, destination: int = 0, word: Word = WORD) -> int:
+        """ write a value to a destination given a mask and the least significant bit
+        """
+        return (destination & (~mask & word.mask)) | (value << lsb)
+
+    def read(self, source: int):
+        """ return the value of this field given a source word
+        """
+        value = self._read(source, self.source_mask, self.source.start)
+
+        if self.destination is None:
+            return value
+
+        return self._write(value, self.destination_mask, self.destination.start, 0)
+
+    def write(self, value: int, destination: int = 0):
+        """ return of the value of this field represented in a destination word
+        """
+        if self.destination is not None:
+            value = self._read(value, self.destination_mask, self.destination.start)
+
+        return self._write(value, self.source_mask, self.source.start, destination)
 
 
+@dataclass
 class Format:
-    """ an instruction format that translates to/from binary/fields
+    """ an instruction format
     """
 
-    # All instruction formats define fields by their bounds.
+    name: str  # e.g. J
     fields: Tuple[Field, ...]
 
-    def encode(self, fields: Tuple[int, ...]) -> int:
-        """ return the packed bit representation of multiple fields
-        """
-        raise NotImplementedError  # TODO
 
-    def decode(self, word: int) -> Tuple[int, ...]:
-        """ unpack the bits representation of an instruction format
-        """
-        raise NotImplementedError  # TODO
+@dataclass
+class Operation:
+    """ a named and numbered category of instructions with the same instruction format
+    """
 
-
-class RType(Format):
-
-    fields = (
-        Field( 0,  6),  # opcode
-        Field( 7, 11),  # rd
-        Field(12, 14),  # funct3
-        Field(15, 19),  # rs1
-        Field(20, 24),  # rs2
-        Field(25, 31),  # funct7
-    )
+    format: Format  # e.g. I-Type
+    opcode: int     # e.g. 0b0110111
+    opname: str     # e.g. SYSTEM
 
 
-class IType(Format):
+@dataclass
+class PseudoInstruction:
+    """ a mnemonic corresponding to values of specific fields
+    """
 
-    fields = (
-        Field( 0,  6),  # opcode
-        Field( 7, 11),  # rd
-        Field(12, 14),  # funct3
-        Field(15, 19),  # rs1
-        Field(20, 31),  # imm[0:11]
-    )
-
-
-class SType(Format):
-
-    fields = (
-        Field( 0,  6),  # opcode
-        Field( 7, 11),  # imm[0:4]
-        Field(12, 14),  # funct3
-        Field(15, 19),  # rs1
-        Field(20, 24),  # rs2
-        Field(25, 31),  # imm[5:11]
-    )
-
-
-class BType(Format):
-
-    fields = (
-        Field( 0,  6),  # opcode
-        Field( 7,  7),  # imm[11]
-        Field( 8, 11),  # imm[1:4]
-        Field(12, 14),  # funct3
-        Field(15, 19),  # rs1
-        Field(20, 24),  # rs2
-        Field(25, 30),  # imm[5:10]
-        Field(31, 31),  # imm[12]
-    )
-
-
-class UType(Format):
-
-    fields = (
-        Field( 0,  6),  # opcode
-        Field( 7, 11),  # rd
-        Field(12, 31),  # imm [12:31]
-    )
-
-
-class JType(Format):
-
-    fields = (
-        Field( 0,  6),  # opcode
-        Field( 7, 11),  # rd
-        Field(12, 19),  # imm[12:19]
-        Field(20, 20),  # imm[11]
-        Field(21, 30),  # imm[1:10]
-        Field(31, 31),  # imm[20]
-    )
+    mnemonic: str               # e.g. "ADDI"
+    operation: Operation        # e.g. OP-IMM, gives the instruction format & opcode
+    constants: Dict[Union[Field, str], int]   # e.g. "funct3": 0b000 for "ADDI"
+    subfields: Tuple[Format] = tuple()   # e.g. "shamt", derived from imm
 
 
 class Instruction:
-
-    # These class attributes are defined by the various subclasses
-    opcode: int
-    format: Format
-
-    # The 64-bit representation of the instruction
-    value: int
-
-    def __init__(self, *fields, value: Optional[int]):
-
-        # Most of the time, the VM is decoding binary into instructions.
-        # In this case, we can avoid the work of computing the instructions
-        # binary representation by just saving the source material.
-        #
-        # Otherwise compute it from the instruction format fields (in the case
-        # of e.g. mnemonic or unit tests).
-        self.value = value if value is not None else self.format.encode(*fields)
-
-    def execute(self, rf: RegisterFile):
-        """ execute the instruction against the state machine
-        """
-        raise NotImplementedError
-
-
-class Decoder:
-    """ binary instructions -> instruction objects
+    """ a named, numbered, and instanced operation on a virtual cpu core
     """
 
-    # Put available instructions here, by class:
-    instruction_classes: Tuple[Type[Instruction]] = (
-        # ...
-    )
+    pseudo: PseudoInstruction  # e.g. "ADDI"
 
-    # A mapping from opcode to Instruction class that is created at runtime and
-    # used to quickly decode bits to a particular instruction.
-    instruction_classes_by_opcode: Dict[int, Type[Instruction]]
-
-    def __init__(self):
-
-        # Create the mapping from opcode to Instruction class
-        self.instruction_classes_by_opcode = {}
-        for instruction_class in self.instruction_classes:
-            self.instruction_classes_by_opcode[instruction_class.opcode] = instruction_class
-
-    def decode(self, word: int) -> Instruction:
-        """ Decode 64 bits into an Instruction object
-        """
-        opcode = word & 0x3f  # 6 bits
-        instruction_class = self.instruction_classes_by_opcode[opcode]
-        instruction_fields = instruction_class.format.decode(word)
-        return instruction_class(*instruction_fields, value=word)
+    def execute(self, rf: RegisterFile):
+        raise NotImplementedError
 
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/pyrisccore/vm/particulars/isa/__init__.py
+++ b/pyrisccore/vm/particulars/isa/__init__.py
@@ -1,0 +1,2 @@
+""" particular risc-v instruction set architectures
+"""

--- a/pyrisccore/vm/particulars/isa/rv32i.py
+++ b/pyrisccore/vm/particulars/isa/rv32i.py
@@ -1,0 +1,359 @@
+""" RISC-V 32-bit Base Integer Instruction Set ("RV32I")
+
+Based on:
+ - "RV32I Base Integer Instruction Set, Version 2.1" Page 31-48 of
+ - https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMAFDQC/riscv-spec-20191213.pdf
+"""
+
+from typing import Dict
+
+from pyrisccore.vm.forms.instruction import Field, Format, PseudoInstruction, Operation
+
+
+# instruction format letter -> Format
+formats: Dict[str, Format] = {
+
+    "R": Format(
+        name="R",
+        fields = (
+            Field(slice( 0,  6), "opcode"),
+            Field(slice( 7, 11), "rd"),
+            Field(slice(12, 14), "funct3"),
+            Field(slice(15, 19), "rs1"),
+            Field(slice(20, 24), "rs2"),
+            Field(slice(25, 31), "funct7"),
+        )
+    ),
+
+    "I": Format(
+        name="I",
+        fields = (
+            Field(slice( 0,  6), "opcode"),
+            Field(slice( 7, 11), "rd"),
+            Field(slice(12, 14), "funct3"),
+            Field(slice(15, 19), "rs1"),
+            Field(slice(20, 31), "imm", slice(0, 11)),
+        )
+    ),
+
+    "S": Format(
+        name="S",
+        fields = (
+            Field(slice( 0,  6), "opcode"),
+            Field(slice( 7, 11), "imm", slice(0, 4)),
+            Field(slice(12, 14), "funct3"),
+            Field(slice(15, 19), "rs1"),
+            Field(slice(20, 24), "rs2"),
+            Field(slice(25, 31), "imm", slice(5, 11)),
+        )
+    ),
+
+    "B": Format(
+        name="B",
+        fields = (
+            Field(slice( 0,  6), "opcode"),
+            Field(slice( 7,  7), "imm", slice(11, 11)),
+            Field(slice( 8, 11), "imm", slice(1, 4)),
+            Field(slice(12, 14), "funct3"),
+            Field(slice(15, 19), "rs1"),
+            Field(slice(20, 24), "rs2"),
+            Field(slice(25, 30), "imm", slice(5, 10)),
+            Field(slice(31, 31), "imm", slice(12)),
+        )
+    ),
+
+    "U": Format(
+        name="U",
+        fields = (
+            Field(slice( 0,  6), "opcode"),
+            Field(slice( 7, 11), "rd"),
+            Field(slice(12, 31), "imm", slice(12, 31)),
+        )
+    ),
+
+    "J": Format(
+        name="J",
+        fields = (
+            Field(slice( 0,  6), "opcode"),
+            Field(slice( 7, 11), "rd"),
+            Field(slice(12, 19), "imm", slice(12, 19)),
+            Field(slice(20, 20), "imm", slice(11, 11)),
+            Field(slice(21, 30), "imm", slice(1, 10)),
+            Field(slice(31, 31), "imm", slice(20, 20)),
+        )
+    ),
+
+}
+
+
+# opcode -> Operation
+operations: Dict[int, Operation] = {
+
+    "OP-IMM":   Operation(formats["I"], 0b0010011, "OP-IMM"),
+    "LUI":      Operation(formats["U"], 0b0110111, "LUI"),
+    "AUIPC":    Operation(formats["U"], 0b0010111, "AUIPC"),
+    "OP":       Operation(formats["R"], 0b0110011, "OP"),
+    "JAL":      Operation(formats["J"], 0b1101111, "JAL"),
+    "JALR":     Operation(formats["I"], 0b1100111, "JALR"),
+    "BRANCH":   Operation(formats["B"], 0b1100011, "BRANCH"),
+    "LOAD":     Operation(formats["I"], 0b0000011, "LOAD"),
+    "STORE":    Operation(formats["S"], 0b0100011, "STORE"),
+    "MISC-MEM": Operation(formats["I"], 0b0001111, "MISC-MEM"),
+    "SYSTEM":   Operation(formats["I"], 0b1110011, "SYSTEM"),
+
+}
+
+
+# mnemonic -> PseudoInstruction
+pseudoinstructions: Dict[str, PseudoInstruction] = {
+
+    # Register-Immediate
+
+    "ADDI": PseudoInstruction("ADDI", operations["OP-IMM"],
+        constants={
+            "funct3": 0b000,
+        },
+    ),
+    "SLTI": PseudoInstruction("SLTI", operations["OP-IMM"],
+        constants={
+            "funct3": 0b000,
+        },
+    ),
+    "SLTIU": PseudoInstruction("SLTIU", operations["OP-IMM"],
+        constants={
+            "funct3": 0b000,
+        },
+    ),
+    "ANDI": PseudoInstruction("ANDI", operations["OP-IMM"],
+        constants={
+            "funct3": 0b000,
+        },
+    ),
+    "ORI": PseudoInstruction("ORI", operations["OP-IMM"],
+        constants={
+            "funct3": 0b000,
+        },
+    ),
+    "XORI": PseudoInstruction("XORI", operations["OP-IMM"],
+        constants={
+            "funct3": 0b000,
+        },
+    ),
+    "SLLI": PseudoInstruction("SLLI", operations["OP-IMM"],
+        constants={
+            "funct3": 0b000,
+            Field(slice(25, 31), "imm", slice(5, 11)): 0,
+        },
+        subfields=(
+            Field(slice(0, 4), "shamt", parent="imm"),
+        ),
+    ),
+    "SRLI": PseudoInstruction("SRLI", operations["OP-IMM"],
+        constants={
+            "funct3": 0b000,
+            Field(slice(25, 31), "imm", slice(5, 11)): 0,
+        },
+        subfields=(
+            Field(slice(0, 4), "shamt", parent="imm"),
+        ),
+    ),
+    "SRAI": PseudoInstruction("SRAI", operations["OP-IMM"],
+        constants={
+            "funct3": 0b000,
+            Field(slice(25, 31), "imm", slice(5, 11)): 0b0100000,
+        },
+        subfields=(
+            Field(slice(0, 4), "shamt", parent="imm"),
+        ),
+    ),
+    "LUI": PseudoInstruction("LUI", operations["LUI"]),
+    "AUIPC": PseudoInstruction("AUIPC", operations["AUIPC"]),
+
+    # Register-Register
+
+    "ADD": PseudoInstruction("ADD", operations["OP"],
+        constants={
+            "funct3": 0b000,
+            "funct7": 0,
+        },
+    ),
+    "SLT": PseudoInstruction("SLT", operations["OP"],
+        constants={
+            "funct3": 0b000,
+            "funct7": 0,
+        },
+    ),
+    "SLTU": PseudoInstruction("SLTU", operations["OP"],
+        constants={
+            "funct3": 0b000,
+            "funct7": 0,
+        },
+    ),
+    "AND": PseudoInstruction("AND", operations["OP"],
+        constants={
+            "funct3": 0b000,
+            "funct7": 0,
+        },
+    ),
+    "OR": PseudoInstruction("OR", operations["OP"],
+        constants={
+            "funct3": 0b000,
+            "funct7": 0,
+        },
+    ),
+    "XOR": PseudoInstruction("XOR", operations["OP"],
+        constants={
+            "funct3": 0b000,
+            "funct7": 0,
+        },
+    ),
+    "SLL": PseudoInstruction("SLL", operations["OP"],
+        constants={
+            "funct3": 0b000,
+            "funct7": 0,
+        },
+    ),
+    "SRL": PseudoInstruction("SRL", operations["OP"],
+        constants={
+            "funct3": 0b000,
+            "funct7": 0,
+        },
+    ),
+    "SUB": PseudoInstruction("SUB", operations["OP"],
+        constants={
+            "funct3": 0b000,
+            "funct7": 0b0100000,
+        },
+    ),
+    "SRA": PseudoInstruction("SRA", operations["OP"],
+        constants={
+            "funct3": 0b000,
+            "funct7": 0b0100000,
+        },
+    ),
+
+    # Unconditional Jumps
+
+    "JAL": PseudoInstruction("JAL", operations["JAL"],
+        subfields=(
+            Field(slice(12, 31), "offset", slice(1, 20)),
+        )
+    ),
+    "JALR": PseudoInstruction("JALR", operations["JALR"],
+        subfields=(
+            Field(slice(20, 31), "offset", slice(0, 11)),
+        )
+    ),
+
+    # Conditional Branches
+
+    "BEQ": PseudoInstruction("BEQ", operations["BRANCH"],
+        constants={
+            "funct3": 0b000,
+        },
+    ),
+    "BNE": PseudoInstruction("BNE", operations["BRANCH"],
+        constants={
+            "funct3": 0b000,
+        },
+    ),
+    "BLT": PseudoInstruction("BLT", operations["BRANCH"],
+        constants={
+            "funct3": 0b000,
+        },
+    ),
+    "BLTU": PseudoInstruction("BLTU", operations["BRANCH"],
+        constants={
+            "funct3": 0b000,
+        },
+    ),
+    "BGE": PseudoInstruction("BGE", operations["BRANCH"],
+        constants={
+            "funct3": 0b000,
+        },
+    ),
+    "BGEU": PseudoInstruction("BGEU", operations["BRANCH"],
+        constants={
+            "funct3": 0b000,
+        },
+    ),
+
+    # Load and Store
+
+    "LOAD": PseudoInstruction("LOAD", operations["LOAD"]),
+    "STORE": PseudoInstruction("STORE", operations["STORE"]),
+
+    # Memory Ordering
+
+    "FENCE": PseudoInstruction("FENCE", operations["FENCE"],
+        constants={
+            "rd": 0,
+            "rs1": 0,
+        },
+        subfields=(
+            Field(slice(20, 20), "SW"),
+            Field(slice(21, 21), "SR"),
+            Field(slice(22, 22), "SO"),
+            Field(slice(23, 23), "SI"),
+            Field(slice(24, 24), "PW"),
+            Field(slice(25, 25), "PR"),
+            Field(slice(26, 26), "PO"),
+            Field(slice(27, 27), "PI"),
+            Field(slice(28, 31), "fm"),
+        ),
+    ),
+
+    # Environment Call and Breakpoints
+
+    "ECALL": PseudoInstruction("ECALL", operations["SYSTEM"],
+        constants={
+            "rd": 0,
+            "rs1": 0,
+            "funct3": 0b000,  # PRIV
+            "imm": 0b000,
+        },
+        subfields=(
+            Field(slice(20, 20), "SW"),
+            Field(slice(21, 21), "SR"),
+            Field(slice(22, 22), "SO"),
+            Field(slice(23, 23), "SI"),
+            Field(slice(24, 24), "PW"),
+            Field(slice(25, 25), "PR"),
+            Field(slice(26, 26), "PO"),
+            Field(slice(27, 27), "PI"),
+            Field(slice(28, 31), "fm"),
+        ),
+    ),
+    "EBREAK": PseudoInstruction("EBREAK", operations["SYSTEM"],
+        constants={
+            "rd": 0,
+            "rs1": 0,
+            "funct3": 0b000,  # PRIV
+            "imm": 0b000,
+        },
+        subfields=(
+            Field(slice(20, 20), "SW"),
+            Field(slice(21, 21), "SR"),
+            Field(slice(22, 22), "SO"),
+            Field(slice(23, 23), "SI"),
+            Field(slice(24, 24), "PW"),
+            Field(slice(25, 25), "PR"),
+            Field(slice(26, 26), "PO"),
+            Field(slice(27, 27), "PI"),
+            Field(slice(28, 31), "fm"),
+        ),
+    ),
+
+
+}
+
+
+aliases: Dict[str, PseudoInstruction] = {
+    "NOP": PseudoInstruction("ADDI", operations["OP-IMM"], {
+        "funct3": 0b000,
+        "imm": 0,
+    }),
+}
+
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -1,25 +1,123 @@
-""" test the building blocks of instruction objects
+""" test the building blocks of an instruction
 """
 
+from typing import List
+
+import pytest
+
+from pyrisccore import PyrisccoreAssertion
 from pyrisccore.vm.forms.instruction import Field
 
 
-def test_field_mask():
+def test_field_validate_slice():
 
-    # Case: 1-bit field starting at bit 0 (lsb)
-    f = Field(0, 0)
-    f.set(0b0001)  # 1 in the lsb
-    assert f.value == 0b1
+    # Case: slice start and stop must be set
+    with pytest.raises(PyrisccoreAssertion):
+        Field._validate_slice(slice(0))
 
-    # Case: 1-bit field starting at bit 1 (left of lsb)
-    f = Field(1, 1)
-    f.set(0b0010)
-    assert f.value == 0b1
+    # Case: slice start/stop must be positive
+    with pytest.raises(PyrisccoreAssertion):
+        Field._validate_slice(slice(-1, 0))
+    with pytest.raises(PyrisccoreAssertion):
+        Field._validate_slice(slice(0, -1))
 
-    # Case: 3-bit field starting at bit 2
-    f = Field(2, 4)
-    f.set(0b00010100)
-    assert f.value == 0b101
+    # Case: slice step must be 1 or None
+    Field(slice(0, 0, 1))
+    with pytest.raises(PyrisccoreAssertion):
+        Field._validate_slice(slice(0, 0, 0))
+    with pytest.raises(PyrisccoreAssertion):
+        Field._validate_slice(slice(0, 0, 2))
+
+
+@pytest.mark.parametrize(
+    ["field", "word", "output"],
+    [
+        # Case: 1-bit field starting at bit 0 (lsb)
+        [Field(source=slice(0, 0)), 0b0001, 0b1],
+
+        # Case: 1-bit field starting at bit 1 (left of lsb)
+        [Field(source=slice(1, 1)), 0b0010, 0b1],
+
+        # Case: 3-bit field starting at bit 2
+        [Field(source=slice(2, 4)), 0b00010100, 0b101],
+
+    ]
+)
+def test_field_read_without_destination(field: Field, word: int, output: int):
+    assert field.read(word) == output
+
+
+@pytest.mark.parametrize(
+    ["field", "args", "output"],
+    [
+        # Case: 1-valued 1-bit field starting at bit 0 (lsb)
+        [Field(source=slice(0, 0)), [0b1, 0b0], 0b1],
+        [Field(source=slice(0, 0)), [0b1, 0b1], 0b1],
+
+        # Case: 1-valued 1-bit field starting at bit 1 (left of lsb)
+        [Field(source=slice(1, 1)), [0b1, 0b000], 0b010],
+        [Field(source=slice(1, 1)), [0b1, 0b001], 0b011],  # <- the one in the 0th position is preserved
+        [Field(source=slice(1, 1)), [0b1, 0b100], 0b110],  # <- the one in the 2nd position is preserved
+
+        # Case: 0-valued 1-bit field starting at bit 0 (lsb)
+        # (just repeat the tests above with 0 as the value to place)
+        [Field(source=slice(0, 0)), [0b0, 0b0], 0b0],
+        [Field(source=slice(0, 0)), [0b0, 0b0], 0b0],
+        [Field(source=slice(0, 0)), [0b0, 0b1], 0b0],
+
+        # Case: 0-valued 1-bit field starting at bit 1 (left of lsb)
+        [Field(source=slice(1, 1)), [0b0, 0b000], 0b000],
+        [Field(source=slice(1, 1)), [0b0, 0b111], 0b101],
+        [Field(source=slice(1, 1)), [0b0, 0b100], 0b100],
+
+    ]
+)
+def test_field_write_without_destination(field: Field, args: List[int], output: int):
+    assert field.write(*args) == output
+
+
+@pytest.mark.parametrize(
+    ["field", "word", "output"],
+    [
+        # Case: 1-bit field sourced from bit 0 (lsb) put at bit 0
+        [Field(source=slice(0, 0), destination=slice(0, 0)), 0b1, 0b1],
+
+        # Case: 1-bit field sourced from bit 1 (lsb) put at bit 0
+        [Field(source=slice(1, 1), destination=slice(0, 0)), 0b10, 0b1],
+
+        # Case: 1-bit field sourced from bit 2 (lsb) put at bit 3
+        [Field(source=slice(2, 2), destination=slice(3, 3)), 0b100, 0b1000],
+
+        # Case: 3-bit field sourced from bit 1 (lsb) put at bit 2
+        [Field(source=slice(1, 3), destination=slice(2, 4)), 0b01110, 0b11100],
+
+    ],
+)
+def test_field_read_with_destination(field: Field, word: int, output: int):
+    assert field.read(word) == output
+
+
+@pytest.mark.parametrize(
+    ["field", "args", "output"],
+    [
+        # ! This is just the inverse of the tests above ^
+
+        # Case: 1-bit field sourced from bit 0 (lsb) put at bit 0
+        [Field(source=slice(0, 0), destination=slice(0, 0)), [0b1], 0b1],
+
+        # Case: 1-bit field sourced from bit 1 (lsb) put at bit 0
+        [Field(source=slice(1, 1), destination=slice(0, 0)), [0b1], 0b10],
+
+        # Case: 1-bit field sourced from bit 2 (lsb) put at bit 3
+        [Field(source=slice(2, 2), destination=slice(3, 3)), [0b1000], 0b100],
+
+        # Case: 3-bit field sourced from bit 1 (lsb) put at bit 2
+        [Field(source=slice(1, 3), destination=slice(2, 4)), [0b11100], 0b01110],
+
+    ],
+)
+def test_field_write_with_destination(field: Field, args: List[int], output: int):
+    assert field.write(*args) == output
 
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
This commit had two goals:

    1. Record enough details about instructions (opcodes, constant
       fields, mnemonics, formats, etc) to be capable of decoding
       instructions from, or encoding instructions to, bits.

    2. Support goal #1 with Python objects and interfaces that make
       recording the particular details about each instruction as
       reasonable and straight-forward as possible.

All RISC-V documentation can be found here:
- https://riscv.org/technical/specifications/

Instruction particulars (opcodes, mnemonics, etc) are documented here:
> "Volume 1, Unprivileged Spec v. 20191213"
- https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMAFDQC/riscv-spec-20191213.pdf

This commit records details for "RV32I", the base ISA.

No details about how to actually execute instructions were added.
Upcoming work is around instruction encoding/decoding. That will involve
enriching the Field object for bit manipulation.