### PR TITLE
Compose one value from multiple fields of an instruction word

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ disable = [
     "missing-function-docstring",
     "too-few-public-methods",
     "missing-final-newline",
+    "too-many-branches",
     "line-too-long",
     "invalid-name",
 ]

--- a/pyrisccore/vm/forms/field.py
+++ b/pyrisccore/vm/forms/field.py
@@ -1,11 +1,23 @@
-""" A "field" is a slice of a word with distinct value
+""" Slices of an instruction word that compose a distinct value
 """
 
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Optional, Tuple
 
 from pyrisccore import PyrisccoreAssertion
 from pyrisccore.vm.forms.word import WORD, Word
+
+
+def bit_count(i: int) -> int:
+    """ Count the set bits in an integer i
+
+    Note: Python 3.10 introduced int.bit_count(); replace when it's released.
+    """
+    count = 0
+    while i != 0:
+        count += i & 0x1
+        i >>= 1
+    return count
 
 
 @dataclass(
@@ -13,27 +25,28 @@ from pyrisccore.vm.forms.word import WORD, Word
     unsafe_hash=True    # <- Once a Field is instantiated, it's effectively frozen.
 )
 class Field:
-    """ A slice of a "word" with distinct value
+    """ A slice of an instruction word
+
+    Example:
+
+     0123456 789AB  <- bit index
+    --------------
+    |1100100|00000  <- values
+    --------------
+     ^^^^^^^        <- ex. "opcode" slice(0, 6) == 0b1100100
     """
 
     # The range of bits in a word for this field's value.
     source: slice
-
-    # The name of the field; multiple Field instances can share this value
-    # to indicate that the bits of their values come from multiple slices.
-    name: Optional[str] = None
     source_mask: int = field(init=False)
+
+    # The name of the field. Fields with the same name compose one Value from multiple slices.
+    name: Optional[str] = None
 
     # Declare which of the source bits map to specific bits of the value.
     # For example, see the "imm" field of the J-Type instruction format.
     destination: Optional[slice] = None
     destination_mask: Optional[int] = field(init=False, default=None)
-
-    # Declare that the value of this field is linked to the value of another field
-    # rather than the instruction word. This is given as either the name of a field
-    # in the instruction format or as the index of a field in the instruction format
-    # counting from the least significant bit (0-indexing).
-    parent: Optional[Union[str, int]] = None
 
     # Number of bits required to represent this field's value.
     size: int = field(init=False)
@@ -45,7 +58,7 @@ class Field:
         size_src = self.source.stop - self.source.start + 1
 
         # Use the source slice
-        self.source_mask: int = self._mask(self.source.start, size_src)
+        self.source_mask: int = self.mask(self.source.start, size_src)
         self.size: int = size_src
 
         # Enforce constraints on the destination slice
@@ -56,7 +69,7 @@ class Field:
                 raise PyrisccoreAssertion(f"'source' and 'destination' slices must be the same size ({size_src} bits vs {size_dst} bits)")
 
             # Use the destination slice
-            self.destination_mask: int = self._mask(self.destination.start, size_dst)
+            self.destination_mask: int = self.mask(self.destination.start, size_dst)
 
     @staticmethod
     def _validate_slice(s: slice):
@@ -70,7 +83,7 @@ class Field:
             raise PyrisccoreAssertion(f"'start' and 'stop' cannot be negative in the slice: {s}")
 
     @staticmethod
-    def _mask(lsb: int, bit_length: int) -> int:
+    def mask(lsb: int, bit_length: int) -> int:
         """ return a mask isolating the value of this particular field
         """
         if bit_length <= 0:
@@ -89,7 +102,7 @@ class Field:
         """
         return (destination & (~mask & word.mask)) | (value << lsb)
 
-    def read(self, source: int):
+    def read(self, source: int) -> int:
         """ return the value of this field given a source word
         """
         value = self._read(source, self.source_mask, self.source.start)
@@ -99,13 +112,98 @@ class Field:
 
         return self._write(value, self.destination_mask, self.destination.start, 0)
 
-    def write(self, value: int, destination: int = 0):
+    def write(self, value: int, destination: int = 0) -> int:
         """ return of the value of this field represented in a destination word
         """
         if self.destination is not None:
             value = self._read(value, self.destination_mask, self.destination.start)
 
         return self._write(value, self.source_mask, self.source.start, destination)
+
+
+@dataclass(
+    frozen=False,       # <- __post_init__() will fail if this is True.
+    unsafe_hash=True    # <- Once a Field is instantiated, it's effectively frozen.
+)
+class Value:
+    """ One or more slices of an instruction word that make up a single value
+    """
+
+    fields: Tuple[Field, ...]
+    name: Optional[str] = None
+
+    source_mask: int = field(init=False)
+    destination_mask: int = field(init=False)
+
+    def __post_init__(self):
+
+        # Constraint: This object works with one or more Field objects
+        if not self.fields:
+            raise PyrisccoreAssertion("One or more Field objects required")
+
+        # Cast self.fields to a tuple if it's a list or another sequence.
+        if not isinstance(self.fields, tuple):
+            self.fields = tuple(self.fields)
+
+        # Constraint: The sum of the sizes of the fields can't exceed XLEN
+        if sum(f.size for f in self.fields) > WORD.xlen:
+            raise PyrisccoreAssertion(f"A composition of Field objects can't exceed XLEN ({WORD.xlen}) size")
+
+        # Constraint:
+        #
+        #   - One Field object makes reading a value simple: the source bits are
+        #     are shifted to the lsb (bit 0) in the destination.
+        #
+        #   - Multiple Field objects require their source bits map explicitly to
+        #     bits in the destination. This is to prevent bits in the source word
+        #     from overwriting already-set bits in the destination.
+        #
+        if len(self.fields) > 1:
+            for f in self.fields:
+                if f.destination is None:
+                    raise PyrisccoreAssertion(f"Field is required to have a destination slice for '{self.name}': {f}")
+
+        # Compute the complete source and destination masks for this value.
+        # Also check that Fields do not overlap in source or destination.
+        self.source_mask = 0
+        self.destination_mask = 0
+
+        # A source->destination mapping isn't required for a single field.
+        if len(self.fields) == 1:
+            self.source_mask = self.fields[0].source_mask
+            if self.fields[0].destination is None:
+                self.destination_mask = Field.mask(0, self.fields[0].size)
+            else:
+                self.destination_mask = self.fields[0].destination_mask
+
+        # ... an is essential for multiple fields.
+        else:
+            source_mask_bit_count = 0
+            destination_mask_bits_count = 0
+            for f in self.fields:
+                self.source_mask |= f.source_mask
+                self.destination_mask |= f.destination_mask
+                if bit_count(self.source_mask) == source_mask_bit_count:
+                    raise PyrisccoreAssertion(f"Field has overlapping source bits: {f}")
+                if bit_count(self.destination_mask) == destination_mask_bits_count:
+                    raise PyrisccoreAssertion(f"Field has overlapping destination bits: {f}")
+                source_mask_bit_count = bit_count(self.source_mask)
+                destination_mask_bits_count = bit_count(self.destination_mask)
+
+    def read(self, source: int) -> int:
+        """ return the value of this field given a source word
+        """
+        value = 0
+        for f in self.fields:
+            value |= f.read(source)
+        return value
+
+    def write(self, value: int, destination: int) -> int:
+        """ return of the value of this field represented in a destination word
+        """
+        for f in self.fields:
+            destination |= f.write(value, destination)
+        return destination
 
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/pyrisccore/vm/particulars/isa/rv32i.py
+++ b/pyrisccore/vm/particulars/isa/rv32i.py
@@ -149,7 +149,7 @@ pseudoinstructions: Dict[str, PseudoInstruction] = {
             Field(slice(25, 31), "imm", slice(5, 11)): 0,
         },
         subfields=(
-            Field(slice(0, 4), "shamt", parent="imm"),
+            Field(slice(20, 24), "shamt"),
         ),
     ),
     "SRLI": PseudoInstruction("SRLI", operations["OP-IMM"],
@@ -158,7 +158,7 @@ pseudoinstructions: Dict[str, PseudoInstruction] = {
             Field(slice(25, 31), "imm", slice(5, 11)): 0,
         },
         subfields=(
-            Field(slice(0, 4), "shamt", parent="imm"),
+            Field(slice(20, 24), "shamt"),
         ),
     ),
     "SRAI": PseudoInstruction("SRAI", operations["OP-IMM"],
@@ -167,7 +167,7 @@ pseudoinstructions: Dict[str, PseudoInstruction] = {
             Field(slice(25, 31), "imm", slice(5, 11)): 0b0100000,
         },
         subfields=(
-            Field(slice(0, 4), "shamt", parent="imm"),
+            Field(slice(20, 24), "shamt"),
         ),
     ),
     "LUI": PseudoInstruction("LUI", operations["LUI"]),


### PR DESCRIPTION
Notes:

 - Removed Field's "parent" attribute. There's no use for this yet and
   I'm probably not going to need it since it's clearer to express all
   Fields in terms of bits of the instruction word as the manual does.

 - "popcount" was implemented as a function ("bit_count()"). I expect
   this to be removed when Python 3.10 is released as it's replaced by
   the upcoming int.bit_count.